### PR TITLE
chore: move CLI config schema

### DIFF
--- a/.build/build.sh
+++ b/.build/build.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+go get github.com/markbates/pkger/cmd/pkger
+pkger
+go generate ./...
+go build -o ./bin/stackhead-cli .

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,13 @@
+# Pull Request
+
+## Requirements
+
 * **Please check if the PR fulfills these requirements**
 - [ ] The commit message follows our guidelines
 - [ ] Tests for the changes have been added (for bug fixes / features)
 - [ ] Docs have been added / updated (for bug fixes / features)
 
+## Details
 
 * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
 

--- a/.github/linters/.golangci.yml
+++ b/.github/linters/.golangci.yml
@@ -1,0 +1,3 @@
+linters-settings:
+  gosec:
+    exclude: G402 # disabled as we allow unsafe SSL certificates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.13
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.13
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
       - name: Build
-        run: go build -v -o bin/stackhead-cli
+        run: sh ./.build/build.sh
 
   release:
     name: Release

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -18,16 +18,15 @@ jobs:
     steps:
 
       - name: Set up Go 1.13
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.13
-        id: go
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
       - name: Build
-        run: go build -v -o bin/stackhead-cli
+        run: sh ./.build/build.sh
 
       - uses: actions/upload-artifact@v2
         with:
@@ -40,10 +39,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.13
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.13
-        id: go
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
@@ -66,6 +64,8 @@ jobs:
         run: pip install ansible==2.10.3
       - name: Print Ansible and Python version
         run: ansible --version && python --version
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
       - name: Download StackHead CLI artifact
         uses: actions/download-artifact@v2
         with:

--- a/.github/workflows/test-cli.yml
+++ b/.github/workflows/test-cli.yml
@@ -78,13 +78,13 @@ jobs:
         run: |
           /home/runner/bin/stackhead-cli init --version ${{ env.STACKHEAD_VERSION }} -v
           git clone --depth=1 --branch ${{ env.STACKHEAD_VERSION }} https://github.com/getstackhead/stackhead.git stackhead_repo
-          /home/runner/bin/stackhead-cli cli validate ./stackhead_repo/schemas/examples/cli-config/valid/cli.yml
-          /home/runner/bin/stackhead-cli module validate ./stackhead_repo/schemas/examples/module-config/valid/container-module.yml
-          /home/runner/bin/stackhead-cli project validate ./stackhead_repo/schemas/examples/project-definition/valid/project.stackhead.yml
-          /home/runner/bin/stackhead-cli project validate ./stackhead_repo/schemas/examples/project-definition/valid/project-secured.stackhead.yaml
+          /home/runner/bin/stackhead-cli cli validate ./schemas/examples/cli-config/valid/cli.yml
+          /home/runner/bin/stackhead-cli module validate ./stackhead_repo/ansible/schemas/examples/module-config/valid/container-module.yml
+          /home/runner/bin/stackhead-cli project validate ./stackhead_repo/ansible/schemas/examples/project-definition/valid/project.stackhead.yml
+          /home/runner/bin/stackhead-cli project validate ./stackhead_repo/ansible/schemas/examples/project-definition/valid/project-secured.stackhead.yaml
 
-          cp ./stackhead_repo/schemas/examples/project-definition/valid/project.stackhead.yml ./stackhead_repo/schemas/examples/project-definition/invalid/project.yml
-          /home/runner/bin/stackhead-cli project validate ./stackhead_repo/schemas/examples/project-definition/invalid/project.yml && returncode=$? || returncode=$?
+          cp ./stackhead_repo/ansible/schemas/examples/project-definition/valid/project.stackhead.yml ./stackhead_repo/ansible/schemas/examples/project-definition/invalid/project.yml
+          /home/runner/bin/stackhead-cli project validate ./stackhead_repo/ansible/schemas/examples/project-definition/invalid/project.yml && returncode=$? || returncode=$?
           if [ $returncode -eq 0 ]; then
             echo "File above should not have validated due to invalid file extension!"
             exit 1

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -18,16 +18,15 @@ jobs:
     steps:
 
       - name: Set up Go 1.13
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v2
         with:
           go-version: 1.13
-        id: go
 
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
       - name: Build
-        run: go build -v -o bin/stackhead-cli
+        run: sh ./.build/build.sh
 
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/test-validator.yml
+++ b/.github/workflows/test-validator.yml
@@ -1,0 +1,28 @@
+name: Test validation schemas
+
+on:
+  push:
+    branches:
+      - master
+      - next
+    paths:
+      - schemas/**
+      - .github/workflows/test-validator.yml
+  pull_request:
+    branches:
+      - master
+    paths:
+      - schemas/**
+      - .github/workflows/test-validator.yml
+
+jobs:
+  test:
+    name: Unit test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Test example file validity
+      working-directory: schemas
+      run: ./test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 bin
 stackhead-cli
 .stackhead-cli.yml
+pkged.go

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang:alpine as builder
 WORKDIR /build
 COPY . /build
-RUN go build -o ./bin/stackhead-cli .
+RUN sh /build/.build/build.sh
 
 FROM pad92/ansible-alpine:2.10.3
 COPY --from=builder /build/bin/stackhead-cli /bin/

--- a/commands/cli/cli.go
+++ b/commands/cli/cli.go
@@ -9,6 +9,7 @@ func GetCommands() *cobra.Command {
 		Use:   "cli",
 		Short: "StackHead CLI commands",
 	}
-	command.AddCommand(Validate)
+	validate := Validate()
+	command.AddCommand(validate)
 	return command
 }

--- a/commands/cli/validate.go
+++ b/commands/cli/validate.go
@@ -1,19 +1,31 @@
 package cli
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/getstackhead/stackhead-cli/routines"
+	"github.com/spf13/cobra"
 )
 
 // Validate is a command object for Cobra that provides the validate command
-var Validate = &cobra.Command{
-	Use:     "validate [path to StackHead CLI configuration file]",
-	Example: "validate ./stackhead-module.yml",
-	Short:   "Validate a StackHead module file",
-	Long:    `validate is used to make sure your StackHead CLI configuration file meets the required syntax.`,
-	Args:    cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		routines.Validate(args[0], "cli-config.schema.json")
-	},
+func Validate() *cobra.Command {
+	var version, branch string
+	var ignoreSslCertificate bool
+	var command = &cobra.Command{
+		Use:     "validate [path to StackHead CLI configuration file]",
+		Example: "validate ./stackhead-module.yml",
+		Short:   "Validate a StackHead module file",
+		Long:    `validate is used to make sure your StackHead CLI configuration file meets the required syntax.`,
+		Args:    cobra.ExactArgs(1),
+		Run: routines.CobraValidationBase(
+			"stackhead_cli",
+			"cli-config.schema.json",
+			version,
+			branch,
+			ignoreSslCertificate,
+		),
+	}
+	command.PersistentFlags().StringVar(&version, "version", "", "Version of schema to use (requires internet connection)")
+	command.PersistentFlags().StringVar(&branch, "branch", "", "Branch of schema to use (requires internet connection)")
+	command.PersistentFlags().BoolVar(&ignoreSslCertificate, "ignore-ssl-certificate", false, "Whether to ignore the SSL certificate for Web request (when --version) is used")
+
+	return command
 }

--- a/commands/module/module.go
+++ b/commands/module/module.go
@@ -9,6 +9,7 @@ func GetCommands() *cobra.Command {
 		Use:   "module",
 		Short: "StackHead module commands",
 	}
-	command.AddCommand(Validate)
+	validate := Validate()
+	command.AddCommand(validate)
 	return command
 }

--- a/commands/module/validate.go
+++ b/commands/module/validate.go
@@ -1,19 +1,31 @@
 package module
 
 import (
-	"github.com/spf13/cobra"
-
 	"github.com/getstackhead/stackhead-cli/routines"
+	"github.com/spf13/cobra"
 )
 
 // Validate is a command object for Cobra that provides the validate command
-var Validate = &cobra.Command{
-	Use:     "validate [path to StackHead module file]",
-	Example: "validate ./stackhead-module.yml",
-	Short:   "Validate a StackHead module file",
-	Long:    `validate is used to make sure your StackHead module file meets the required syntax.`,
-	Args:    cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		routines.Validate(args[0], "module-config.schema.json")
-	},
+func Validate() *cobra.Command {
+	var version, branch string
+	var ignoreSslCertificate bool
+	var command = &cobra.Command{
+		Use:     "validate [path to StackHead module file]",
+		Example: "validate ./stackhead-module.yml",
+		Short:   "Validate a StackHead module file",
+		Long:    `validate is used to make sure your StackHead module file meets the required syntax.`,
+		Args:    cobra.ExactArgs(1),
+		Run: routines.CobraValidationBase(
+			"ansible_collection",
+			"module-config.schema.json",
+			version,
+			branch,
+			ignoreSslCertificate,
+		),
+	}
+	command.PersistentFlags().StringVar(&version, "version", "", "Version of schema to use (requires internet connection)")
+	command.PersistentFlags().StringVar(&branch, "branch", "", "Branch of schema to use (requires internet connection)")
+	command.PersistentFlags().BoolVar(&ignoreSslCertificate, "ignore-ssl-certificate", false, "Whether to ignore the SSL certificate for Web request (when --version) is used")
+
+	return command
 }

--- a/commands/project/project.go
+++ b/commands/project/project.go
@@ -9,6 +9,6 @@ func GetCommands() *cobra.Command {
 		Use:   "project",
 		Short: "Project commands",
 	}
-	command.AddCommand(DeployApplication, DestroyApplication, Validate)
+	command.AddCommand(DeployApplication, DestroyApplication, Validate())
 	return command
 }

--- a/commands/project/validate.go
+++ b/commands/project/validate.go
@@ -9,17 +9,32 @@ import (
 )
 
 // Validate is a command object for Cobra that provides the validate command
-var Validate = &cobra.Command{
-	Use:     "validate [path to project definition file]",
-	Example: "validate ./my-project-definition.yml",
-	Short:   "Validate a project definition file",
-	Long:    `validate is used to make sure your project definition file meets the StackHead project definition syntax.`,
-	Args:    cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
-		routines.Validate(args[0], "project-definition.schema.json")
+func Validate() *cobra.Command {
+	var version, branch string
+	var ignoreSslCertificate bool
+	var command = &cobra.Command{
+		Use:     "validate [path to project definition file]",
+		Example: "validate ./my-project-definition.yml",
+		Short:   "Validate a project definition file",
+		Long:    `validate is used to make sure your project definition file meets the StackHead project definition syntax.`,
+		Args:    cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			routines.CobraValidationBase(
+				"ansible_collection",
+				"project-definition.schema.json",
+				version,
+				branch,
+				ignoreSslCertificate,
+			)(cmd, args)
 
-		if !strings.HasSuffix(args[0], ".stackhead.yml") && !strings.HasSuffix(args[0], ".stackhead.yaml") {
-			panic("The file name must end in \".stackhead.yml\" or \".stackhead.yaml\"!")
-		}
-	},
+			if !strings.HasSuffix(args[0], ".stackhead.yml") && !strings.HasSuffix(args[0], ".stackhead.yaml") {
+				panic("The file name must end in \".stackhead.yml\" or \".stackhead.yaml\"!")
+			}
+		},
+	}
+	command.PersistentFlags().StringVar(&version, "version", "", "Version of schema to use (requires internet connection)")
+	command.PersistentFlags().StringVar(&branch, "branch", "", "Branch of schema to use (requires internet connection)")
+	command.PersistentFlags().BoolVar(&ignoreSslCertificate, "ignore-ssl-certificate", false, "Whether to ignore the SSL certificate for Web request (when --version) is used")
+
+	return command
 }

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,12 @@ go 1.13
 
 require (
 	github.com/briandowns/spinner v1.11.1
+	github.com/markbates/pkger v0.17.1
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/saitho/jsonschema-validator v1.0.0
+	github.com/saitho/jsonschema-validator v1.2.0
 	github.com/smartystreets/goconvey v1.6.4
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.1
+	github.com/xeipuuv/gojsonschema v1.2.0
 	gopkg.in/yaml.v2 v2.2.8
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ cloud.google.com/go/firestore v1.1.0/go.mod h1:ulACoGHTpvq5r8rxGJ4ddJZBZqakUQqCl
 cloud.google.com/go/pubsub v1.0.1/go.mod h1:R0Gpsv3s54REJCy4fxDixWD93lHJMoZTyQ2kNxGRt3I=
 cloud.google.com/go/storage v1.0.0/go.mod h1:IhtSnM/ZTZV8YYJWCY8RULGVqBDmpoyjwiyrjsg+URw=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
+github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
@@ -37,6 +38,7 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
@@ -51,6 +53,8 @@ github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2
 github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9GBnD5lWE=
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/gobuffalo/here v0.6.0 h1:hYrd0a6gDmWxBM4TnrGw8mQg24iSVoIkHEk7FodQcBI=
+github.com/gobuffalo/here v0.6.0/go.mod h1:wAG085dHOYqUpf+Ap+WOdrPTp5IYcDAs/x7PLa8Y5fM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -71,6 +75,7 @@ github.com/google/pprof v0.0.0-20190515194954-54271f7e092f/go.mod h1:zfwlbNMJ+OI
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
@@ -110,12 +115,16 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
+github.com/markbates/pkger v0.17.1 h1:/MKEtWqtc0mZvu9OinB9UzVN9iYCwLWuyUv4Bw+PCno=
+github.com/markbates/pkger v0.17.1/go.mod h1:0JoVlrol20BSywW79rN3kdFFsE5xYM+rSCQDXbLhiuI=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.2 h1:/bC9yWikZXAL9uJdulbSfyVNIR3n3trXl+v8+1sx8mU=
 github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
@@ -143,6 +152,7 @@ github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/posener/complete v1.1.1/go.mod h1:em0nMJCgc9GFtwrmVmEMR/ZL6WyhyjMBndrE9hABlRI=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
@@ -158,8 +168,8 @@ github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6So
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
-github.com/saitho/jsonschema-validator v1.0.0 h1:UFzk8/6utT7QGP+zngFw9RbLAdU19Sg5DzDoPj601K0=
-github.com/saitho/jsonschema-validator v1.0.0/go.mod h1:W/1Q1xQ+vyYxANlTEpi6hQBEHJPEi4wJmCBkdIehFvQ=
+github.com/saitho/jsonschema-validator v1.2.0 h1:bWSvTla54F5cziZsxLBR0mlN3gTw9hjrkFuZU55kO+E=
+github.com/saitho/jsonschema-validator v1.2.0/go.mod h1:W/1Q1xQ+vyYxANlTEpi6hQBEHJPEi4wJmCBkdIehFvQ=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
@@ -186,6 +196,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -313,6 +325,7 @@ google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ij
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/ini.v1 v1.51.0 h1:AQvPpx3LzTDM0AjnIRlVFwFFGC+npRopjZxLJj6gdno=
@@ -321,8 +334,8 @@ gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/main.go
+++ b/main.go
@@ -1,9 +1,11 @@
+//go:generate pkger
 package main
 
 import (
 	"fmt"
 	"os"
 
+	"github.com/markbates/pkger"
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -29,6 +31,7 @@ to quickly create a Cobra application.`,
 
 // main adds all child commands to the root command and sets flags appropriately.
 func main() {
+	_ = pkger.Include("/schemas")
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/routines/exec.go
+++ b/routines/exec.go
@@ -61,7 +61,10 @@ func ExecAnsibleGalaxyCollection(args ...string) error {
 	}
 
 	// We have to set a relative path, otherwise ansible-galaxy will do weird things...
-	relCollectionsPath, _ := filepath.Rel(cwd, "/")
+	relCollectionsPath, err := filepath.Rel(cwd, "/")
+	if err != nil {
+		return err
+	}
 	args = append(args, "-p "+relCollectionsPath+"/../.."+collectionDir[0])
 
 	// Prepend "collection" task to args

--- a/routines/validation.go
+++ b/routines/validation.go
@@ -1,26 +1,86 @@
 package routines
 
 import (
+	"crypto/tls"
 	"fmt"
+	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 
-	"github.com/getstackhead/stackhead-cli/ansible"
+	"github.com/markbates/pkger"
+	"github.com/markbates/pkger/pkging"
 	jsonschema "github.com/saitho/jsonschema-validator/validator"
+	"github.com/spf13/cobra"
+	"github.com/xeipuuv/gojsonschema"
+
+	"github.com/getstackhead/stackhead-cli/ansible"
 )
 
-func Validate(filePath string, schemaFile string) {
-	var collectionDir, err = ansible.GetStackHeadCollectionLocation()
-	collectionAbsDir, err := filepath.Abs(collectionDir)
-	if err != nil {
-		panic(err)
+type ValidationSource string
+
+func CobraValidationBase(source string, schemaFile string, version string, branch string, ignoreSslCertificate bool) func(cmd *cobra.Command, args []string) {
+	return func(cmd *cobra.Command, args []string) {
+		if len(version) > 0 {
+			source = "https://schema.stackhead.io/stackhead-cli/tag/" + version + "/-"
+		} else if len(branch) > 0 {
+			source = "https://schema.stackhead.io/stackhead-cli/branch/" + branch + "/-"
+		}
+
+		http.DefaultTransport.(*http.Transport).TLSClientConfig = &tls.Config{
+			MinVersion:         1,
+			InsecureSkipVerify: ignoreSslCertificate,
+		}
+		Validate(args[0], schemaFile, source)
 	}
+}
 
-	schemaPath := filepath.Join(collectionAbsDir, "schemas", schemaFile)
-	result, err := jsonschema.ValidateFile(filePath, schemaPath)
+func Validate(filePath string, schemaFile string, source string) {
+	var sourceDir, absSourceDir string
+	var err error
+	var result *gojsonschema.Result
 
-	if err != nil {
-		panic(err.Error())
+	switch source {
+	case "ansible_collection":
+		sourceDir, err = ansible.GetStackHeadCollectionLocation()
+		if err != nil {
+			panic(err)
+		}
+		absSourceDir, err = filepath.Abs(sourceDir)
+		if err != nil {
+			panic(err)
+		}
+		schemaPath := filepath.Join(absSourceDir, "schemas", schemaFile)
+		result, err = jsonschema.ValidateFile(filePath, schemaPath)
+		if err != nil {
+			panic(err.Error())
+		}
+	case "stackhead_cli":
+		// Use schema stored in binary
+		var f pkging.File
+		f, err = pkger.Open("/schemas/" + schemaFile)
+		if err != nil {
+			panic(err.Error())
+		}
+		defer f.Close()
+
+		var sl []byte
+		sl, err = ioutil.ReadAll(f)
+		if err != nil {
+			panic(err.Error())
+		}
+		result, err = jsonschema.ValidateFileWithInput(filePath, sl)
+		if err != nil {
+			panic(err.Error())
+		}
+	default:
+		url := fmt.Sprintf("%s/%s", source, schemaFile)
+		fmt.Fprintf(os.Stdout, "Validating with schema from URL: %s\n", url)
+		// Pull from online Schemastore, source contains the URL
+		result, err = jsonschema.ValidateFile(filePath, url)
+		if err != nil {
+			panic(err.Error())
+		}
 	}
 
 	errorMessage := jsonschema.ShouldValidate(result)
@@ -31,7 +91,7 @@ func Validate(filePath string, schemaFile string) {
 		if err != nil {
 			panic(err.Error())
 		}
-		os.Exit(1)
+		defer func() { os.Exit(1) }()
 	}
 	if err != nil {
 		panic(err.Error())

--- a/schemas/cli-config.schema.json
+++ b/schemas/cli-config.schema.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "StackHead CLI config",
+  "description": "StackHead CLI config file",
+  "type": "object",
+  "required": ["modules"],
+  "properties": {
+    "modules": {
+      "type": "object",
+      "required": ["webserver", "container"],
+      "properties": {
+        "webserver": {
+          "type": "string"
+        },
+        "container": {
+          "type": "string"
+        },
+        "plugins": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/examples/cli-config/invalid/cli-no-container.yml
+++ b/schemas/examples/cli-config/invalid/cli-no-container.yml
@@ -1,0 +1,5 @@
+---
+modules:
+  webserver: nginx
+  plugins:
+    - watchtower

--- a/schemas/examples/cli-config/invalid/cli-no-webserver.yml
+++ b/schemas/examples/cli-config/invalid/cli-no-webserver.yml
@@ -1,0 +1,5 @@
+---
+modules:
+  container: docker
+  plugins:
+    - watchtower

--- a/schemas/examples/cli-config/valid/cli-noplugins.yml
+++ b/schemas/examples/cli-config/valid/cli-noplugins.yml
@@ -1,0 +1,4 @@
+---
+modules:
+  webserver: nginx
+  container: docker

--- a/schemas/examples/cli-config/valid/cli.yml
+++ b/schemas/examples/cli-config/valid/cli.yml
@@ -1,0 +1,6 @@
+---
+modules:
+  webserver: nginx
+  container: docker
+  plugins:
+    - watchtower

--- a/schemas/test.sh
+++ b/schemas/test.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+TEST_FAILED=0
+
+validate_files()
+{
+  SCHEMAFILE="./${1}.schema.json"
+  EXAMPLE_DIR="examples/${1}"
+  echo "### TESTING ${SCHEMAFILE} ... START\n"
+	printf "Valid %s files should be valid:\n" "${EXAMPLE_DIR}"
+	for filename in "${EXAMPLE_DIR}"/valid/*; do
+		if bin/jsonschema-validator "${SCHEMAFILE}" "${filename}" 1> /dev/null; then
+		: # file is valid
+		else
+			TEST_FAILED=1
+			echo "- ERROR: File ${filename} is invalid." > /dev/stderr
+		fi
+	done
+	printf "\n\n"
+	# Invalid files should be invalid
+	printf "Invalid %s files should be invalid.\n" "${EXAMPLE_DIR}"
+	for filename in "${EXAMPLE_DIR}"/invalid/*; do
+		if bin/jsonschema-validator "${SCHEMAFILE}" "${filename}" 2> /dev/null; then
+			TEST_FAILED=1
+			echo "- ERROR: ${filename} is valid." > /dev/stderr
+		fi
+	done
+  echo "### TESTING ${SCHEMAFILE} ... END\n"
+}
+
+validate_files "cli-config"
+
+if [ $TEST_FAILED -eq 0 ]; then
+  echo 'All tests succeeded.'
+else
+  echo 'Some tests failed!'
+fi
+
+exit $TEST_FAILED

--- a/schemas/test.sh
+++ b/schemas/test.sh
@@ -6,14 +6,14 @@ validate_files()
 {
   SCHEMAFILE="./${1}.schema.json"
   EXAMPLE_DIR="examples/${1}"
-  echo "### TESTING ${SCHEMAFILE} ... START\n"
+  printf "### TESTING %s ... START\n" "${SCHEMAFILE}"
 	printf "Valid %s files should be valid:\n" "${EXAMPLE_DIR}"
 	for filename in "${EXAMPLE_DIR}"/valid/*; do
 		if bin/jsonschema-validator "${SCHEMAFILE}" "${filename}" 1> /dev/null; then
 		: # file is valid
 		else
 			TEST_FAILED=1
-			echo "- ERROR: File ${filename} is invalid." > /dev/stderr
+			printf "ERROR: File %s is invalid." "${filename}" > /dev/stderr
 		fi
 	done
 	printf "\n\n"
@@ -22,10 +22,10 @@ validate_files()
 	for filename in "${EXAMPLE_DIR}"/invalid/*; do
 		if bin/jsonschema-validator "${SCHEMAFILE}" "${filename}" 2> /dev/null; then
 			TEST_FAILED=1
-			echo "- ERROR: ${filename} is valid." > /dev/stderr
+			printf "ERROR: %s is valid." "${filename}" > /dev/stderr
 		fi
 	done
-  echo "### TESTING ${SCHEMAFILE} ... END\n"
+  printf "### TESTING %s ... END\n" "${SCHEMAFILE}"
 }
 
 validate_files "cli-config"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

Moves CLI config schema from main repository to this repository and adds it to the built binary.

Adds new options `--version` and `--branch` to validation commands for validating against a schema from schema.stackhead.io.
The option `--ignore-ssl-certificate` can be used to disable SSL certificate check if they cause problems.